### PR TITLE
feat: layer position follow the monitor focus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ src/wlr-layer-shell-unstable-v1-protocol.c:
 src/wlr-layer-shell-unstable-v1-client-protocol.h:
 	$(WAYLAND_SCANNER) client-header $(LAYER_SHELL_XML) $@
 
-# Generate Foreign Toplevel Management Protocol (新增)
 src/wlr-foreign-toplevel-management-unstable-v1-protocol.c:
 	$(WAYLAND_SCANNER) private-code $(FOREIGN_TOPLEVEL_XML) $@
 src/wlr-foreign-toplevel-management-unstable-v1-client-protocol.h:
@@ -63,7 +62,6 @@ src/wlr-foreign-toplevel-management-unstable-v1-client-protocol.h:
 src/main.o: src/main.c src/xdg-shell-client-protocol.h src/wlr-layer-shell-unstable-v1-client-protocol.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
-# 新增：wlr_backend 需要 foreign toplevel 协议头文件
 src/wlr_backend.o: src/wlr_backend.c src/wlr-foreign-toplevel-management-unstable-v1-client-protocol.h
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -21,6 +21,9 @@
 #   context  = Group tiled windows by workspace+app (power user)
 mode = context
 
+# The panel position whether to follow the focus of your monitor
+follow_monitor = false
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │                              THEME SETTINGS                               │
 # └───────────────────────────────────────────────────────────────────────────┘

--- a/src/config.c
+++ b/src/config.c
@@ -14,6 +14,7 @@
 /* --- Defaults ("Snappy Slate" Theme) --- */
 static void set_defaults(Config *cfg) {
   cfg->mode = MODE_CONTEXT;
+  cfg->follow_monitor = false;
 
   /* Default Theme Colors */
   cfg->background = 0x1e1e2e;
@@ -80,6 +81,9 @@ static void apply_value(Config *cfg, const char *section, const char *key,
         cfg->mode = MODE_CONTEXT;
       else if (strcasecmp(val, "overview") == 0)
         cfg->mode = MODE_OVERVIEW;
+    } else if (strcasecmp(key, "follow_monitor") == 0) {
+      cfg->follow_monitor =
+          (strcasecmp(val, "true") == 0 || strcmp(val, "1") == 0);
     }
   }
   /* Colors (from theme or manual override) */

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,7 @@ typedef struct {
   bool show_letter_fallback;
 
   /* View Mode */
+  bool follow_monitor;
   ViewMode mode;
 } Config;
 


### PR DESCRIPTION
 It cannot be used in multiple monitors now. As far as I know, the panel cannot actively sense the focus changes of the monitor. The only way to make it follow the monitor  is to destroy the panel and recreate it.