### PR TITLE
feat: show workspace number in window title UI

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -207,7 +207,15 @@ static void draw_card(cairo_t *cr, WindowInfo *win, double x, double y,
   pango_layout_set_width(title, (w - 20) * PANGO_SCALE);
   pango_layout_set_ellipsize(title, PANGO_ELLIPSIZE_END);
   pango_layout_set_alignment(title, PANGO_ALIGN_CENTER);
-  pango_layout_set_text(title, win->title, -1);
+  char full_title[512];
+  if (win->workspace_id > 0) {
+    snprintf(full_title, sizeof(full_title), "[%d] %s", win->workspace_id, win->title);
+  }
+  else {
+    snprintf(full_title, sizeof(full_title), "%s", win->title);
+  }
+
+  pango_layout_set_text(title, full_title, -1);
 
   cairo_set_source_rgb(cr, txt_r, txt_g, txt_b);
   cairo_move_to(cr, x + 10, y + 10);


### PR DESCRIPTION
Struct Update: Added workspace_id to WindowInfo in src/main.h.

IPC Logic: Updated the Hyprland client parsing logic to extract the workspace -> id field from the JSON response.

UI Rendering: Modified src/render.c to format the title as [ID] Window Title. Added safety checks for invalid/negative workspace IDs.

<img width="799" height="394" alt="image" src="https://github.com/user-attachments/assets/f7804212-0476-4b96-93ad-0c53cf0d839d" />




