### PR TITLE
fix: hide switcher before activating window to prevent focus override

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -135,7 +135,6 @@ static void keyboard_key(void *data, struct wl_keyboard *keyboard,
   case XKB_KEY_KP_Enter:
     if (app_state->count > 0 && app_state->selected_index >= 0 &&
         app_state->selected_index < app_state->count) {
-      switch_to_window(app_state->windows[app_state->selected_index].address);
       if (on_alt_release)
         on_alt_release();
     }

--- a/src/main.c
+++ b/src/main.c
@@ -314,12 +314,17 @@ static void show_switcher(void) {
 }
 
 static void select_and_hide(void) {
+  char *address = NULL;
   if (visible && app_state.count > 0 && backend) {
     WindowInfo *win = &app_state.windows[app_state.selected_index];
+    address = strdup(win->address);
     LOG("Switching to: %s (using %s backend)", win->title, backend->get_name());
-    backend->activate_window(win->address);
   }
   hide_switcher();
+  if (address) {
+    backend->activate_window(address);
+    free(address);
+  }
 }
 
 static void handle_command(const char *cmd) {


### PR DESCRIPTION
fixes a race condition when calling activate_window

hide_switcher() needs to run first otherwise hypr doesn't properly focus the selected window 