### PR TITLE
feat: add arrow key navigation

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -27,6 +27,7 @@ typedef struct {
   /* UI Dimensions (Shared with Input/Render) */
   uint32_t width;
   uint32_t height;
+  int cols; /* Number of columns in the current grid layout */
 } AppState;
 
 /* Initialize AppState */

--- a/src/input.c
+++ b/src/input.c
@@ -122,6 +122,42 @@ static void keyboard_key(void *data, struct wl_keyboard *keyboard,
     }
     break;
 
+  case XKB_KEY_Left:
+    if (app_state->count > 0) {
+      app_state->selected_index--;
+      if (app_state->selected_index < 0)
+        app_state->selected_index = app_state->count - 1;
+      render_ui(app_state, app_state->width, app_state->height, output_scale);
+    }
+    break;
+
+  case XKB_KEY_Right:
+    if (app_state->count > 0) {
+      app_state->selected_index++;
+      if (app_state->selected_index >= app_state->count)
+        app_state->selected_index = 0;
+      render_ui(app_state, app_state->width, app_state->height, output_scale);
+    }
+    break;
+
+  case XKB_KEY_Up:
+    if (app_state->count > 0 && app_state->cols > 0) {
+      int next = app_state->selected_index - app_state->cols;
+      if (next >= 0)
+        app_state->selected_index = next;
+      render_ui(app_state, app_state->width, app_state->height, output_scale);
+    }
+    break;
+
+  case XKB_KEY_Down:
+    if (app_state->count > 0 && app_state->cols > 0) {
+      int next = app_state->selected_index + app_state->cols;
+      if (next < app_state->count)
+        app_state->selected_index = next;
+      render_ui(app_state, app_state->width, app_state->height, output_scale);
+    }
+    break;
+
   case XKB_KEY_Escape:
     if (on_escape)
       on_escape();

--- a/src/main.c
+++ b/src/main.c
@@ -303,6 +303,8 @@ static void show_switcher(void) {
   app_state.selected_index = (app_state.count > 1) ? 1 : 0;
 
   calculate_dimensions(&app_state, &app_state.width, &app_state.height);
+  int max_cols = config ? config->max_cols : 5;
+  app_state.cols = (app_state.count < max_cols) ? app_state.count : max_cols;
   zwlr_layer_surface_v1_set_size(layer_surface, app_state.width,
                                  app_state.height);
   zwlr_layer_surface_v1_set_keyboard_interactivity(layer_surface, 1);


### PR DESCRIPTION
adds basic left/right/up/down arrow key navigation to selector

note: 

- up/down doesn't wrap; felt better that way
- left/right does wrap to next row