### PR TITLE
Add configurable workspace and monitor filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ name = catppuccin-mocha.ini
 # overview = Show all windows individually
 # context  = Group tiled windows by workspace + app class
 mode = context
+# none | workspace:current | monitor:current | !workspace:-1
+filter = !workspace:-1
 
 [theme]
 name = snappy-slate.ini
@@ -379,6 +381,7 @@ title_size = 10
 
 [general]
 mode = context
+filter = !workspace:-1
 follow_monitor = true
 show_workspace_badge = true
 dismiss_modifier = alt

--- a/config.ini.example
+++ b/config.ini.example
@@ -21,6 +21,16 @@
 #   context  = Group tiled windows by workspace+app (power user)
 mode = context
 
+# Window filter expression:
+#   none              = Do not filter windows
+#   !workspace:-1     = Exclude special/scratchpad workspace windows (default)
+#   workspace:current = Show only windows on the active workspace
+#   monitor:current   = Show only windows assigned to the focused monitor
+#   workspace:2       = Show only windows on workspace 2
+#   monitor:1         = Show only windows on monitor 1
+# Include rules are OR'ed together; exclude rules prefixed with ! always win.
+filter = !workspace:-1
+
 # The panel position whether to follow the focus of your monitor
 follow_monitor = true
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ sequenceDiagram
     
     Note over D: Parse window data
 
-        Note over D: Extract per window:<br/>• address (unique ID)<br/>• title<br/>• class (app name)<br/>• workspace.id<br/>• workspace.name<br/>• focusHistoryID<br/>• floating (bool)
+        Note over D: Extract per window:<br/>• address (unique ID)<br/>• title<br/>• class (app name)<br/>• workspace.id<br/>• workspace.name<br/>• monitor<br/>• focusHistoryID<br/>• floating (bool)
     
 ```
 
@@ -80,8 +80,11 @@ sequenceDiagram
 | `class` | `string` | App class name (e.g., `kitty`, `firefox`) |
 | `workspace.id` | `int` | Workspace number |
 | `workspace.name` | `string` | Workspace name (e.g., `"1"`, `"music"`, `"special:scratchpad"`) |
+| `monitor` | `int` | Hyprland monitor ID |
 | `focusHistoryID` | `int` | MRU position (0 = most recent) |
 | `floating` | `bool` | Tiled or floating window |
+
+If `filter` uses a `current` value, the backend first reads `j/activeworkspace` and keeps only matching clients before sorting and context aggregation. The default `filter = !workspace:-1` preserves upstream behavior by excluding special/scratchpad workspace windows.
 
 ---
 
@@ -274,11 +277,13 @@ typedef struct {
 
 ```c
 typedef enum { MODE_OVERVIEW, MODE_CONTEXT } ViewMode;
+typedef enum { WINDOW_FILTER_WORKSPACE, WINDOW_FILTER_MONITOR } WindowFilterField;
 
 typedef struct {
-  ViewMode mode;        // Overview or Context
-  int max_cols;         // Grid column limit
-  char icon_theme[64];  // Icon theme name
+  ViewMode mode;                  // Overview or Context
+  WindowFilterRule filter_rules[]; // workspace/monitor include and exclude rules
+  int max_cols;                   // Grid column limit
+  char icon_theme[64];            // Icon theme name
   // ... colors, dimensions
 } Config;
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,7 @@
 ```ini
 [general]
 mode = context
+filter = !workspace:-1
 
 [theme]
 name = catppuccin-mocha.ini
@@ -54,6 +55,7 @@ mindmap
   root((config.ini))
     general
       mode
+      filter
     theme
       colors
       borders
@@ -106,6 +108,7 @@ flowchart LR
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|
 | `mode` | `overview`, `context` | `context` | Window grouping mode |
+| `filter` | Filter expression | `!workspace:-1` | Optional window scope expression. Include rules select windows; exclude rules prefixed with `!` always win. |
 | `dismiss_modifier` | `alt`, `super`, `shift`, `control`, or comma-separated | `alt` | Modifier(s) that dismiss the switcher when released. Must match your Hyprland keybinding. |
 | `show_workspace_badge` | `true`, `false` | `true` | Show workspace indicator badge on each card |
 | `follow_monitor` | `true`, `false` | `false` | Panel follows the focused monitor |
@@ -122,6 +125,25 @@ flowchart LR
 [general]
 mode = context  # Enable intelligent grouping
 ```
+
+### Window Filter
+
+```ini
+[general]
+filter = workspace:current
+```
+
+| Filter | Behavior |
+|--------|----------|
+| `none` | Do not filter windows |
+| `!workspace:-1` | Exclude special/scratchpad workspace windows |
+| `workspace:current` | Show only windows on the currently active workspace |
+| `monitor:current` | Show only windows assigned to the currently focused monitor |
+| `workspace:2` | Show only windows on workspace 2 |
+| `monitor:1` | Show only windows on monitor 1 |
+| `!workspace:-1,workspace:current` | Show current workspace windows, excluding special/scratchpad windows |
+
+Rules are comma-separated. Positive rules are OR'ed together. Exclude rules start with `!` and always override positive matches.
 
 ### 🏷️ Workspace Badge
 
@@ -438,6 +460,7 @@ icon_letter_size = 24
 
 [general]
 mode = context
+filter = !workspace:-1
 show_workspace_badge = true
 
 [theme]

--- a/src/config.c
+++ b/src/config.c
@@ -16,6 +16,11 @@
 /* --- Defaults ("Snappy Slate" Theme) --- */
 static void set_defaults(Config *cfg) {
   cfg->mode = MODE_CONTEXT;
+  cfg->filter_rule_count = 1;
+  cfg->filter_rules[0].exclude = true;
+  cfg->filter_rules[0].field = WINDOW_FILTER_WORKSPACE;
+  cfg->filter_rules[0].value_kind = WINDOW_FILTER_VALUE_ID;
+  cfg->filter_rules[0].id = -1;
   cfg->follow_monitor = false;
   cfg->show_workspace_badge = true;
   cfg->sticky_mode = false;
@@ -83,6 +88,109 @@ static char *trim(char *str) {
   return str;
 }
 
+static bool parse_filter_rule(char *token, WindowFilterRule *rule) {
+  token = trim(token);
+  if (!token || token[0] == '\0')
+    return false;
+
+  rule->exclude = false;
+  if (token[0] == '!') {
+    rule->exclude = true;
+    token = trim(token + 1);
+  }
+
+  char *colon = strchr(token, ':');
+  if (!colon)
+    return false;
+
+  *colon = '\0';
+  char *field = trim(token);
+  char *value = trim(colon + 1);
+
+  if (strcasecmp(field, "workspace") == 0 ||
+      strcasecmp(field, "ws") == 0) {
+    rule->field = WINDOW_FILTER_WORKSPACE;
+  } else if (strcasecmp(field, "monitor") == 0 ||
+             strcasecmp(field, "mon") == 0) {
+    rule->field = WINDOW_FILTER_MONITOR;
+  } else {
+    return false;
+  }
+
+  if (strcasecmp(value, "current") == 0 || strcasecmp(value, "active") == 0) {
+    rule->value_kind = WINDOW_FILTER_VALUE_CURRENT;
+    rule->id = 0;
+    return true;
+  }
+
+  char *end = NULL;
+  long id = strtol(value, &end, 10);
+  if (end == value || *trim(end) != '\0')
+    return false;
+
+  rule->value_kind = WINDOW_FILTER_VALUE_ID;
+  rule->id = (int)id;
+  return true;
+}
+
+static void add_filter_rule(Config *cfg, WindowFilterRule rule) {
+  if (cfg->filter_rule_count >= WINDOW_FILTER_MAX_RULES) {
+    LOG("Too many filter rules; ignoring extra rule");
+    return;
+  }
+  cfg->filter_rules[cfg->filter_rule_count++] = rule;
+}
+
+static void parse_window_filter(Config *cfg, const char *val) {
+  cfg->filter_rule_count = 0;
+
+  if (!val || val[0] == '\0' || strcasecmp(val, "none") == 0 ||
+      strcasecmp(val, "off") == 0 || strcasecmp(val, "false") == 0 ||
+      strcasecmp(val, "all") == 0) {
+    return;
+  }
+
+  /* Compatibility with the older single-scope values. */
+  if (strcasecmp(val, "current_workspace") == 0 ||
+      strcasecmp(val, "current-workspace") == 0 ||
+      strcasecmp(val, "current workspace") == 0 ||
+      strcasecmp(val, "workspace") == 0) {
+    WindowFilterRule rule = {.exclude = false,
+                             .field = WINDOW_FILTER_WORKSPACE,
+                             .value_kind = WINDOW_FILTER_VALUE_CURRENT,
+                             .id = 0};
+    add_filter_rule(cfg, rule);
+    return;
+  }
+
+  if (strcasecmp(val, "current_monitor") == 0 ||
+      strcasecmp(val, "current-monitor") == 0 ||
+      strcasecmp(val, "current monitor") == 0 ||
+      strcasecmp(val, "monitor") == 0) {
+    WindowFilterRule rule = {.exclude = false,
+                             .field = WINDOW_FILTER_MONITOR,
+                             .value_kind = WINDOW_FILTER_VALUE_CURRENT,
+                             .id = 0};
+    add_filter_rule(cfg, rule);
+    return;
+  }
+
+  char buf[512];
+  strncpy(buf, val, sizeof(buf) - 1);
+  buf[sizeof(buf) - 1] = '\0';
+
+  char *saveptr = NULL;
+  for (char *token = strtok_r(buf, ",", &saveptr); token;
+       token = strtok_r(NULL, ",", &saveptr)) {
+    WindowFilterRule rule;
+    if (parse_filter_rule(token, &rule)) {
+      add_filter_rule(cfg, rule);
+    } else {
+      LOG("Unknown filter rule: %s", trim(token));
+    }
+  }
+}
+
 /* --- Parse a single key-value pair --- */
 static void apply_value(Config *cfg, const char *section, const char *key,
                         const char *val) {
@@ -93,6 +201,8 @@ static void apply_value(Config *cfg, const char *section, const char *key,
         cfg->mode = MODE_CONTEXT;
       else if (strcasecmp(val, "overview") == 0)
         cfg->mode = MODE_OVERVIEW;
+    } else if (strcasecmp(key, "filter") == 0) {
+      parse_window_filter(cfg, val);
     } else if (strcasecmp(key, "follow_monitor") == 0) {
       cfg->follow_monitor =
           (strcasecmp(val, "true") == 0 || strcmp(val, "1") == 0);
@@ -309,6 +419,8 @@ static void create_default_config(const char *path) {
   fprintf(f, "[general]\n");
   fprintf(f, "# mode = context | overview\n");
   fprintf(f, "mode = context\n\n");
+  fprintf(f, "# filter = none | workspace:current | monitor:current | !workspace:-1\n");
+  fprintf(f, "filter = !workspace:-1\n\n");
   fprintf(f, "[theme]\n");
   fprintf(f, "# Available: snappy-slate, tokyo-night, catppuccin-mocha,\n");
   fprintf(f, "#            dracula, nord, gruvbox-dark, rose-pine, etc.\n");

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,27 @@ typedef enum {
   MODE_OVERVIEW, /* Show all windows individually */
   MODE_CONTEXT   /* Group tiled windows by workspace + app class */
 } ViewMode;
+
+/* Window filter expression */
+#define WINDOW_FILTER_MAX_RULES 16
+
+typedef enum {
+  WINDOW_FILTER_WORKSPACE,
+  WINDOW_FILTER_MONITOR
+} WindowFilterField;
+
+typedef enum {
+  WINDOW_FILTER_VALUE_ID,
+  WINDOW_FILTER_VALUE_CURRENT
+} WindowFilterValueKind;
+
+typedef struct {
+  bool exclude;                    /* true for !workspace:-1 */
+  WindowFilterField field;         /* workspace or monitor */
+  WindowFilterValueKind value_kind; /* numeric id or current */
+  int id;                          /* used when value_kind is ID */
+} WindowFilterRule;
+
 /* Theme configuration */
 typedef struct {
   /* Colors (0xRRGGBBAA) */
@@ -49,6 +70,8 @@ typedef struct {
   bool follow_monitor;
   bool show_workspace_badge;
   ViewMode mode;
+  WindowFilterRule filter_rules[WINDOW_FILTER_MAX_RULES];
+  int filter_rule_count;
   bool sticky_mode;
 
   /* Dismiss modifier: which modifier release hides the switcher (e.g. alt, super) */

--- a/src/hyprland.c
+++ b/src/hyprland.c
@@ -18,6 +18,13 @@
 
 static char *get_socket_path(void);
 
+typedef struct {
+  bool has_current_workspace_id;
+  bool has_current_monitor_id;
+  int current_workspace_id;
+  int current_monitor_id;
+} FilterTarget;
+
 int hyprland_backend_init(void) {
   /* Hyprland backend doesn't need special initialization */
   /* Just check if we can connect */
@@ -189,8 +196,150 @@ static char *hyprland_request(const char *cmd) {
   return resp;
 }
 
+static void filter_target_init(FilterTarget *target) {
+  target->has_current_workspace_id = false;
+  target->has_current_monitor_id = false;
+  target->current_workspace_id = -1;
+  target->current_monitor_id = -1;
+}
+
+static int query_focused_monitor_id(int *monitor_id) {
+  char *json = hyprland_request("j/monitors");
+  if (!json)
+    return -1;
+
+  struct json_object *root = json_tokener_parse(json);
+  free(json);
+  if (!root || !json_object_is_type(root, json_type_array)) {
+    if (root)
+      json_object_put(root);
+    return -1;
+  }
+
+  int result = -1;
+  size_t len = json_object_array_length(root);
+  for (size_t i = 0; i < len; i++) {
+    struct json_object *obj = json_object_array_get_idx(root, i);
+    struct json_object *focused, *id;
+
+    if (!json_object_object_get_ex(obj, "focused", &focused) ||
+        !json_object_get_boolean(focused))
+      continue;
+    if (!json_object_object_get_ex(obj, "id", &id))
+      continue;
+
+    *monitor_id = json_object_get_int(id);
+    result = 0;
+    break;
+  }
+
+  json_object_put(root);
+  return result;
+}
+
+static int query_filter_target(FilterTarget *target) {
+  filter_target_init(target);
+
+  char *json = hyprland_request("j/activeworkspace");
+  if (!json)
+    return -1;
+
+  struct json_object *root = json_tokener_parse(json);
+  free(json);
+  if (!root || !json_object_is_type(root, json_type_object)) {
+    if (root)
+      json_object_put(root);
+    return -1;
+  }
+
+  struct json_object *workspace_id, *monitor_id;
+  if (json_object_object_get_ex(root, "id", &workspace_id)) {
+    target->current_workspace_id = json_object_get_int(workspace_id);
+    target->has_current_workspace_id = true;
+  }
+  if (json_object_object_get_ex(root, "monitorID", &monitor_id)) {
+    target->current_monitor_id = json_object_get_int(monitor_id);
+    target->has_current_monitor_id = true;
+  }
+
+  json_object_put(root);
+
+  if (!target->has_current_monitor_id) {
+    target->has_current_monitor_id =
+        (query_focused_monitor_id(&target->current_monitor_id) == 0);
+  }
+
+  return (target->has_current_workspace_id || target->has_current_monitor_id)
+             ? 0
+             : -1;
+}
+
+static bool rule_uses_current(const WindowFilterRule *rule) {
+  return rule->value_kind == WINDOW_FILTER_VALUE_CURRENT;
+}
+
+static bool config_filter_uses_current(const Config *cfg) {
+  if (!cfg)
+    return false;
+
+  for (int i = 0; i < cfg->filter_rule_count; i++) {
+    if (rule_uses_current(&cfg->filter_rules[i]))
+      return true;
+  }
+
+  return false;
+}
+
+static bool rule_matches_client(const WindowFilterRule *rule,
+                                const FilterTarget *target, int workspace_id,
+                                int monitor_id) {
+  int actual = rule->field == WINDOW_FILTER_WORKSPACE ? workspace_id : monitor_id;
+  int expected = rule->id;
+
+  if (rule->value_kind == WINDOW_FILTER_VALUE_CURRENT) {
+    if (rule->field == WINDOW_FILTER_WORKSPACE) {
+      if (!target || !target->has_current_workspace_id)
+        return false;
+      expected = target->current_workspace_id;
+    } else {
+      if (!target || !target->has_current_monitor_id)
+        return false;
+      expected = target->current_monitor_id;
+    }
+  }
+
+  return actual == expected;
+}
+
+static bool client_matches_filter(int workspace_id, int monitor_id,
+                                  const Config *cfg,
+                                  const FilterTarget *target) {
+  if (!cfg || cfg->filter_rule_count <= 0)
+    return true;
+
+  bool has_include_rule = false;
+  bool include_matched = false;
+
+  for (int i = 0; i < cfg->filter_rule_count; i++) {
+    const WindowFilterRule *rule = &cfg->filter_rules[i];
+    bool matched = rule_matches_client(rule, target, workspace_id, monitor_id);
+
+    if (rule->exclude && matched)
+      return false;
+
+    if (!rule->exclude) {
+      has_include_rule = true;
+      if (matched)
+        include_matched = true;
+    }
+  }
+
+  return !has_include_rule || include_matched;
+}
+
 /* --- JSON Parsing --- */
-static int parse_clients(const char *json_str, AppState *state) {
+static int parse_clients(const char *json_str, AppState *state,
+                         const Config *cfg, const FilterTarget *target) {
   struct json_object *root = json_tokener_parse(json_str);
   if (!root || !json_object_is_type(root, json_type_array)) {
     if (root)
@@ -201,7 +350,8 @@ static int parse_clients(const char *json_str, AppState *state) {
   size_t len = json_object_array_length(root);
   for (size_t i = 0; i < len; i++) {
     struct json_object *obj = json_object_array_get_idx(root, i);
-    struct json_object *ws_obj, *ws_id, *ws_name, *addr, *title, *cls, *focus, *floating;
+    struct json_object *ws_obj, *ws_id, *ws_name, *addr, *title, *cls, *focus,
+        *floating, *monitor;
 
     if (!json_object_object_get_ex(obj, "workspace", &ws_obj))
       continue;
@@ -209,7 +359,12 @@ static int parse_clients(const char *json_str, AppState *state) {
       continue;
 
     int wid = json_object_get_int(ws_id);
-     if (wid == -1) 
+
+    int mid = -1;
+    if (json_object_object_get_ex(obj, "monitor", &monitor))
+      mid = json_object_get_int(monitor);
+
+    if (!client_matches_filter(wid, mid, cfg, target))
       continue;
 
     json_object_object_get_ex(ws_obj, "name", &ws_name);
@@ -305,7 +460,15 @@ int update_window_list(AppState *state, Config *cfg) {
   if (!json)
     return -1;
 
-  if (parse_clients(json, state) < 0) {
+  FilterTarget target;
+  filter_target_init(&target);
+  const Config *filter_cfg = cfg;
+  if (config_filter_uses_current(cfg) && query_filter_target(&target) < 0) {
+    LOG("Failed to resolve current filter target (showing all windows)");
+    filter_cfg = NULL;
+  }
+
+  if (parse_clients(json, state, filter_cfg, &target) < 0) {
     free(json);
     return -1;
   }


### PR DESCRIPTION
This PR adds a small filter expression for controlling which windows Snappy Switcher shows.

Motivation: with agentic coding workflows, I often end up with many windows spread across workspaces. In that setup, global Alt+Tab can become noisy, and being able to switch only within the current workspace makes the
flow much faster.

The new config supports examples like:

```
filter = workspace:current
Show only windows from the current workspace.

filter = !workspace:-1
Show all windows except those from workspace -1.

filter = monitor:current, !workspace:-1
Show windows from the current monitor, except workspace -1.

```
Default behavior stays aligned with the current behavior by excluding workspace:-1.

I’m not deeply familiar with the project, but this was useful in my setup, so I wanted to share it in case it fits the direction of Snappy Switcher. Happy to adjust the naming or syntax if you prefer a different
approach.

Tested with:

make
git diff --check