### PR TITLE
feat: add per-state badge colors

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -84,6 +84,8 @@ name = snappy-slate.ini
 # bundle_bg = #313244ff        # Context-mode stacked card background
 # badge_bg = #89b4faff         # Group count badge circle
 # badge_text_color = #cdd6f4ff # Group count badge number
+# badge_bg_selected = #89b4faff         # Badge background for selected card
+# badge_text_color_selected = #cdd6f4ff # Badge text for selected card
 
 # Border and corner styling
 border_width = 2

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -185,6 +185,8 @@ graph TB
 | `bundle_bg` | `#313244ff` | Context-mode stacked card background |
 | `badge_bg` | `#89b4faff` | Group count & workspace badge background |
 | `badge_text_color` | `#cdd6f4ff` | Badge text color |
+| `badge_bg_selected` | `#89b4faff` | Badge background for selected card |
+| `badge_text_color_selected` | `#cdd6f4ff` | Badge text for selected card |
 
 ### Border & Corner Options
 
@@ -192,6 +194,28 @@ graph TB
 |-----|---------|-------------|
 | `border_width` | `2` | Border thickness (px) |
 | `corner_radius` | `12` | Rounded corner radius (px) |
+
+### Per-State Badge Colors
+
+By default, badge colors (`badge_bg` and `badge_text_color`) apply to all cards. You can optionally define separate colors for the selected card's badges:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `badge_bg_selected` | Falls back to `badge_bg` | Badge background for selected card |
+| `badge_text_color_selected` | Falls back to `badge_text_color` | Badge text for selected card |
+
+**Example use case:** Highlight the active card's workspace badge with a distinct accent color while keeping other badges neutral.
+
+```ini
+[theme]
+# Neutral badges for non-selected cards
+badge_bg = #ffffffff
+badge_text_color = #000000ff
+
+# Accent badges for selected card
+badge_bg_selected = #7f22feff
+badge_text_color_selected = #ffffffff
+```
 
 ```ini
 [theme]
@@ -207,6 +231,8 @@ subtext_color = #6c7086ff
 bundle_bg = #1e1e2eff
 badge_bg = #89b4faff
 badge_text_color = #cdd6f4ff
+badge_bg_selected = #89b4faff
+badge_text_color_selected = #cdd6f4ff
 border_width = 2
 corner_radius = 12
 ```
@@ -451,6 +477,8 @@ subtext_color = #6c7086ff
 bundle_bg = #1e1e2eff
 badge_bg = #ca9ee6ff
 badge_text_color = #1e1e2eff
+badge_bg_selected = #ca9ee6ff
+badge_text_color_selected = #1e1e2eff
 border_width = 2
 corner_radius = 12
 

--- a/src/config.c
+++ b/src/config.c
@@ -31,6 +31,8 @@ static void set_defaults(Config *cfg) {
   cfg->bundle_bg = 0x313244ff;
   cfg->badge_bg = 0x89b4faff;
   cfg->badge_text_color = 0xcdd6f4ff;
+  cfg->badge_bg_selected = 0;
+  cfg->badge_text_color_selected = 0;
   cfg->border_width = 2;
   cfg->card_radius = 12;
 
@@ -127,6 +129,10 @@ static void apply_value(Config *cfg, const char *section, const char *key,
       cfg->badge_bg = parse_hex_color(val);
     else if (strcasecmp(key, "badge_text_color") == 0)
       cfg->badge_text_color = parse_hex_color(val);
+    else if (strcasecmp(key, "badge_bg_selected") == 0)
+      cfg->badge_bg_selected = parse_hex_color(val);
+    else if (strcasecmp(key, "badge_text_color_selected") == 0)
+      cfg->badge_text_color_selected = parse_hex_color(val);
     else if (strcasecmp(key, "border_width") == 0)
       cfg->border_width = atoi(val);
     else if (strcasecmp(key, "corner_radius") == 0)
@@ -368,6 +374,14 @@ Config *load_config_from(const char *path) {
     load_theme(theme_name, cfg);
 
   parse_ini_file(path, cfg, NULL, 0);
+
+  /* Fallback: If _selected colors weren't set (still 0), inherit from base colors */
+  if (cfg->badge_bg_selected == 0) {
+    cfg->badge_bg_selected = cfg->badge_bg;
+  }
+  if (cfg->badge_text_color_selected == 0) {
+    cfg->badge_text_color_selected = cfg->badge_text_color;
+  }
 
   return cfg;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -22,6 +22,8 @@ typedef struct {
   uint32_t bundle_bg;
   uint32_t badge_bg;
   uint32_t badge_text_color;
+  uint32_t badge_bg_selected;
+  uint32_t badge_text_color_selected;
 
   /* Layout */
   int card_width;

--- a/src/render.c
+++ b/src/render.c
@@ -321,6 +321,8 @@ static void draw_card(cairo_t *cr, WindowInfo *win, double x, double y,
   double bnd_r, bnd_g, bnd_b, bnd_a;
   double bdg_r, bdg_g, bdg_b, bdg_a;
   double bdt_r, bdt_g, bdt_b, bdt_a;
+  double bdg_sel_r, bdg_sel_g, bdg_sel_b, bdg_sel_a;
+  double bdt_sel_r, bdt_sel_g, bdt_sel_b, bdt_sel_a;
 
   if (cfg) {
     color_to_rgba(cfg->card_bg, &bg_r, &bg_g, &bg_b, &bg_a);
@@ -330,6 +332,8 @@ static void draw_card(cairo_t *cr, WindowInfo *win, double x, double y,
     color_to_rgba(cfg->bundle_bg, &bnd_r, &bnd_g, &bnd_b, &bnd_a);
     color_to_rgba(cfg->badge_bg, &bdg_r, &bdg_g, &bdg_b, &bdg_a);
     color_to_rgba(cfg->badge_text_color, &bdt_r, &bdt_g, &bdt_b, &bdt_a);
+    color_to_rgba(cfg->badge_bg_selected, &bdg_sel_r, &bdg_sel_g, &bdg_sel_b, &bdg_sel_a);
+    color_to_rgba(cfg->badge_text_color_selected, &bdt_sel_r, &bdt_sel_g, &bdt_sel_b, &bdt_sel_a);
   }
 
   int w = cfg ? cfg->card_width : 200;
@@ -389,7 +393,10 @@ static void draw_card(cairo_t *cr, WindowInfo *win, double x, double y,
     double by = y + h - 24;
 
     /* Badge BG */
-    cairo_set_source_rgba(cr, bdg_r, bdg_g, bdg_b, bdg_a);
+    if (selected)
+      cairo_set_source_rgba(cr, bdg_sel_r, bdg_sel_g, bdg_sel_b, bdg_sel_a);
+    else
+      cairo_set_source_rgba(cr, bdg_r, bdg_g, bdg_b, bdg_a);
     cairo_arc(cr, bx, by, 10, 0, 2 * M_PI);
     cairo_fill(cr);
 
@@ -400,7 +407,10 @@ static void draw_card(cairo_t *cr, WindowInfo *win, double x, double y,
     int bw, bh;
     pango_layout_get_pixel_size(bl, &bw, &bh);
 
-    cairo_set_source_rgba(cr, bdt_r, bdt_g, bdt_b, bdt_a);
+    if (selected)
+      cairo_set_source_rgba(cr, bdt_sel_r, bdt_sel_g, bdt_sel_b, bdt_sel_a);
+    else
+      cairo_set_source_rgba(cr, bdt_r, bdt_g, bdt_b, bdt_a);
     cairo_move_to(cr, bx - bw / 2.0, by - bh / 2.0);
     pango_cairo_show_layout(cr, bl);
     g_object_unref(bl);
@@ -422,12 +432,18 @@ static void draw_card(cairo_t *cr, WindowInfo *win, double x, double y,
     double wy = y + h - badge_h - 10;
 
     /* Badge background */
-    cairo_set_source_rgba(cr, bdg_r, bdg_g, bdg_b, bdg_a);
+    if (selected)
+      cairo_set_source_rgba(cr, bdg_sel_r, bdg_sel_g, bdg_sel_b, bdg_sel_a);
+    else
+      cairo_set_source_rgba(cr, bdg_r, bdg_g, bdg_b, bdg_a);
     draw_rounded_rect(cr, wx, wy, badge_w, badge_h, 4.0);
     cairo_fill(cr);
 
     /* Badge text */
-    cairo_set_source_rgba(cr, bdt_r, bdt_g, bdt_b, bdt_a);
+    if (selected)
+      cairo_set_source_rgba(cr, bdt_sel_r, bdt_sel_g, bdt_sel_b, bdt_sel_a);
+    else
+      cairo_set_source_rgba(cr, bdt_r, bdt_g, bdt_b, bdt_a);
     cairo_move_to(cr, wx + (badge_w - ww) / 2.0, wy + (badge_h - wh) / 2.0);
     pango_cairo_show_layout(cr, wl);
     g_object_unref(wl);


### PR DESCRIPTION
Closes: #40 

## Summary
Adds support for different badge colors on selected vs non-selected cards through two new optional theme keys.

## Changes
- Added `badge_bg_selected` and `badge_text_color_selected` to `Config` struct
- Implemented parsing and fallback logic in config loader
- Modified badge rendering to use conditional colors based on selection state
- Updated documentation with examples

## New Theme Keys
- `badge_bg_selected` - Badge background color for the currently selected card
- `badge_text_color_selected` - Badge text color for the currently selected card

## Backward Compatibility
Fully backward compatible. When these keys are not set, badges automatically inherit colors from `badge_bg` and `badge_text_color` (existing behavior).

## Affected Components
- Workspace badges (bottom-left pill)
- Count badges (bottom-right circle)

## Testing Environment

- **OS:** Arch Linux
- **Kernel:** 7.0.9-arch2-1
- **WM:** Hyprland v0.55.2 (built from branch v0.55.2 at commit 39d7e209)
- **Base Version:** snappy-switcher v3.2.0