### PR TITLE
fix scripts on nixos pointing to /usr/local locations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,18 @@
             make
           '';
 
+          postPatch = ''
+            patchShebangs scripts/
+            substituteInPlace scripts/install-config.sh \
+              --replace-fail "/usr/local" "$out"
+            substituteInPlace scripts/snappy-wrapper.sh \
+              --replace-fail "/usr/local" "$out"
+            substituteInPlace src/config.c \
+              --replace-fail "/usr/local" "$out"
+            substituteInPlace snappy-switcher.service \
+              --replace-fail "/usr/local" "$out"
+          '';
+
           installPhase = ''
             mkdir -p $out/bin
             mkdir -p $out/share/snappy-switcher/themes


### PR DESCRIPTION
Added a postPatch step to substitute the `/usr/local` path (which does not exist on NixOS) with the Nix store output in some of the scripts. 

This should resolve an issue I had where the snappy-install-config did not properly copy the default themes into the `~/.config/snappy-switcher/themes`