### PR TITLE
docs: add wayland-protocols-devel to Fedora/RHEL installation instruc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ makepkg -si
 <summary><b>Fedora / RHEL</b></summary>
 
 ```bash
-sudo dnf install wayland-devel cairo-devel pango-devel json-c-devel libxkbcommon-devel glib2-devel librsvg2-devel
+sudo dnf install wayland-devel cairo-devel pango-devel json-c-devel libxkbcommon-devel glib2-devel librsvg2-devel wayland-protocols-devel
 ```
 
 > A Copr way to install things will be included soon (Community maintained pkgs will be appreciated)


### PR DESCRIPTION
…tions

Added `wayland-protocols-devel` to the required packages for Fedora/RHEL installation. This resolves potential build issues by ensuring all necessary Wayland protocol headers are available.
