### PR TITLE
feat: add ignore_pinned option to exclude pinned overlays (e.g. PiP) from the switcher

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -32,6 +32,14 @@ show_workspace_badge = true
 # false = Immediately jump to the previous window (index 1)
 sticky_mode = false
 
+# Ignore Pinned: exclude pinned windows from the switcher list.
+# A pinned window is floating, shown on every workspace, and always-on-top
+# (e.g. a browser Picture-in-Picture mini-player). Since it's already visible
+# on every workspace, cycling to it in an MRU switcher does nothing useful.
+# true  = hide pinned windows from the switcher
+# false = list pinned windows like any other window (default)
+ignore_pinned = false
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │                              THEME SETTINGS                               │
 # └───────────────────────────────────────────────────────────────────────────┘

--- a/src/config.c
+++ b/src/config.c
@@ -19,6 +19,7 @@ static void set_defaults(Config *cfg) {
   cfg->follow_monitor = false;
   cfg->show_workspace_badge = true;
   cfg->sticky_mode = false;
+  cfg->ignore_pinned = false;
   /* Default Fallback / Debug Colors (0xRRGGBBAA) */
   cfg->background = 0xff0000ff;
   cfg->card_bg = 0x0000ffff;
@@ -106,6 +107,9 @@ static void apply_value(Config *cfg, const char *section, const char *key,
           (strcasecmp(val, "true") == 0 || strcmp(val, "1") == 0);
     } else if (strcasecmp(key, "sticky_mode") == 0) {
       cfg->sticky_mode =
+          (strcasecmp(val, "true") == 0 || strcmp(val, "1") == 0);
+    } else if (strcasecmp(key, "ignore_pinned") == 0) {
+      cfg->ignore_pinned =
           (strcasecmp(val, "true") == 0 || strcmp(val, "1") == 0);
     }
   }

--- a/src/config.h
+++ b/src/config.h
@@ -59,6 +59,7 @@ typedef struct {
   bool show_workspace_badge;
   ViewMode mode;
   bool sticky_mode;
+  bool ignore_pinned; /* Exclude pinned (always-on-top, all-workspace) windows, e.g. PiP */
 
 } Config;
 

--- a/src/data.h
+++ b/src/data.h
@@ -16,6 +16,7 @@ typedef struct {
   int focus_history_id; /* Focus history ID (0 = most recently focused) */
   bool is_active;       /* Whether this window is currently focused */
   bool is_floating;     /* Whether this window is floating (not tiled) */
+  bool is_pinned;       /* Whether this window is pinned (shown on all workspaces, always on top) */
   int group_count;      /* Number of windows in this group */
 } WindowInfo;
 

--- a/src/hyprland.c
+++ b/src/hyprland.c
@@ -335,7 +335,8 @@ static int get_active_workspace_id(void) {
  *            workspace.id matches this value.  Special workspaces
  *            (id == -1) are always excluded regardless.
  */
-static int parse_clients(const char *json_str, AppState *state, int target_ws) {
+static int parse_clients(const char *json_str, AppState *state, int target_ws,
+                         bool ignore_pinned) {
   struct json_object *root = json_tokener_parse(json_str);
   if (!root || !json_object_is_type(root, json_type_array)) {
     if (root)
@@ -348,7 +349,7 @@ static int parse_clients(const char *json_str, AppState *state, int target_ws) {
     struct json_object *obj = json_object_array_get_idx(root, i);
     struct json_object *ws_obj = NULL, *ws_id = NULL, *ws_name = NULL,
                        *addr = NULL, *title = NULL, *cls = NULL,
-                       *focus = NULL, *floating = NULL;
+                       *focus = NULL, *floating = NULL, *pinned = NULL;
 
     if (!json_object_object_get_ex(obj, "workspace", &ws_obj))
       continue;
@@ -371,6 +372,14 @@ static int parse_clients(const char *json_str, AppState *state, int target_ws) {
     json_object_object_get_ex(obj, "class", &cls);
     json_object_object_get_ex(obj, "focusHistoryID", &focus);
     json_object_object_get_ex(obj, "floating", &floating);
+    json_object_object_get_ex(obj, "pinned", &pinned);
+
+    /* Pinned filter: skip always-on-top, all-workspace overlays (e.g. browser
+     * Picture-in-Picture) when ignore_pinned is set. A pinned window is visible
+     * on every workspace already, so cycling to it in an MRU switcher is a no-op. */
+    bool is_pinned = pinned ? json_object_get_boolean(pinned) : false;
+    if (ignore_pinned && is_pinned)
+      continue;
 
     WindowInfo info;
     info.address = safe_strdup(json_object_get_string(addr));
@@ -381,6 +390,7 @@ static int parse_clients(const char *json_str, AppState *state, int target_ws) {
     info.focus_history_id = focus ? json_object_get_int(focus) : 9999;
     info.is_active = (info.focus_history_id == 0);
     info.is_floating = floating ? json_object_get_boolean(floating) : false;
+    info.is_pinned = is_pinned;
     info.group_count = 1;
 
     app_state_add(state, &info);
@@ -413,6 +423,7 @@ static void aggregate_context(AppState *state) {
       out[out_count].focus_history_id = win->focus_history_id;
       out[out_count].is_active = win->is_active;
       out[out_count].is_floating = true;
+      out[out_count].is_pinned = win->is_pinned;
       out[out_count].group_count = 1;
       out_count++;
     } else {
@@ -436,6 +447,7 @@ static void aggregate_context(AppState *state) {
         out[out_count].focus_history_id = win->focus_history_id;
         out[out_count].is_active = win->is_active;
         out[out_count].is_floating = false;
+        out[out_count].is_pinned = win->is_pinned;
         out[out_count].group_count = 1;
         out_count++;
       }
@@ -468,7 +480,7 @@ int update_window_list(AppState *state, Config *cfg, bool is_linear) {
   if (!json)
     return -1;
 
-  if (parse_clients(json, state, target_ws) < 0) {
+  if (parse_clients(json, state, target_ws, cfg->ignore_pinned) < 0) {
     free(json);
     return -1;
   }

--- a/src/wlr_backend.c
+++ b/src/wlr_backend.c
@@ -501,6 +501,7 @@ int wlr_get_windows(AppState *state, Config *config, bool is_linear) {
 
     info.is_active = curr->is_active;
     info.is_floating = 0;
+    info.is_pinned = false; /* wlroots backend has no pin concept */
     info.group_count = 1;
     info.focus_history_id = curr->is_active ? 0 : info.focus_history_id;
 


### PR DESCRIPTION
Generated through agentic engineering with Claude Opus 4.8.

## Summary

Adds a `[general]` config option **`ignore_pinned`** (boolean, default `false`) that excludes pinned windows from the switcher list and cycle.

A pinned window in Hyprland is floating, shown on every workspace, and always-on-top — e.g. a browser Picture-in-Picture mini-player. Because such a window is already visible on every workspace, cycling to it in an MRU switcher is a no-op. This adds an opt-in filter for that case, in the same spirit as the existing special-workspace skip (and the "ignore certain windows" request in #25).

## Changes

- **`src/data.h`** — add `WindowInfo.is_pinned`, set at every construction site (client parse, context aggregation, wlroots backend) so the field is never left uninitialized.
- **`src/hyprland.c`** — read the `pinned` flag from `j/clients`; in `parse_clients`, skip the window when `ignore_pinned` is set. The flag is threaded from `Config` via `update_window_list` (no globals).
- **`src/config.{c,h}`** — parse the new key in `[general]` and default it to `false`, mirroring `sticky_mode`.
- **`config.ini.example`** — document the option in the existing comment style.

## Compatibility

- Default `false` → **no behavior change** for existing users.
- When `true`, only pinned overlays are dropped; all other windows are unaffected.
- Builds clean under `-Wall -Wextra`.

## Testing

Verified on Hyprland 0.55.4: with a Firefox Picture-in-Picture floated + pinned via a window rule, `Alt+Tab` no longer lists or cycles to it when `ignore_pinned = true`; setting it back to `false` restores the previous behavior.
